### PR TITLE
Updated k2hr3 system nodejs version from 10 to 16

### DIFF
--- a/devpack/bin/devpack.sh
+++ b/devpack/bin/devpack.sh
@@ -636,10 +636,10 @@ fi
 # So do upgrade nodejs and npm at first.
 #
 if [ ${IS_DEBIAN} -eq 1 ]; then
-	curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+	curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 	K2HDKC_DEV_PACKAGE=k2hdkc-dev
 else
-	curl -sL https://rpm.nodesource.com/setup_10.x | sudo -E bash -
+	curl -sL https://rpm.nodesource.com/setup_16.x | sudo -E bash -
 	K2HDKC_DEV_PACKAGE=k2hdkc-devel
 fi
 sudo ${PKG_INSTALLER} install -y nodejs


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
Since the NodeJS 10 version for `k2hr3_app` / `k2hr3_api` devstack setup is low (not supported now), changed to use the latest 16 version.
