### PR TITLE
Updated ChangeLog for release 1.0.6

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+k2hr3-utils (1.0.6) unstable; urgency=low
+
+  * Updated NodeJS version and CentOS is no longer supported - #32
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Tue, 10 Dec 2024 15:14:58 +0900
+
 k2hr3-utils (1.0.5) unstable; urgency=low
 
   * Reverted k2hdkc data file path in config.templ - #30


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 1.0.5 to 1.0.6
- Updated NodeJS version and CentOS is no longer supported - #32